### PR TITLE
add sslscan proxy feature to test EAP-TLS over IKEv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,4 +389,60 @@ alice_1  | [2020-02-18 11:46:11.049] [DEBUG  ] IKE_SA: 4032e4155ba9ceb6. Generat
 alice_1  | [2020-02-18 11:46:11.050] [DEBUG  ] IKE_SA: 4032e4155ba9ceb6. Generated sk_ei: 18339f5431707fd825698fdfa8dfc4f203de6d08ceb66e762fb56670dd7f772c
 alice_1  | [2020-02-18 11:46:11.050] [DEBUG  ] IKE_SA: 4032e4155ba9ceb6. Generated sk_er: e93a45f53f61686224028c89ec7a6f8870bc2b729fc13b5851ca53d59c5a347f
 alice_1  | [2020-02-18 11:46:11.050] [INFO   ] IKE_SA: 4032e4155ba9ceb6. Created CHILD_SA (0edffee0, 92ea861a)
-``` 
+```
+
+# doing sslscan with EAP-TLS
+## example config
+
+```
+test-tunnel:
+  my_addr: 1.2.3.4
+  peer_addr: vpn.example.org
+
+  my_auth:
+    id: "client.example.org"
+    eap:
+      identity: user@example.org
+
+  # peer's authentication details
+  peer_auth:
+    id: 
+      type: ID_DER_ASN1_DN
+      hex: <HEX of peer ID as shown in debug log>
+
+    # peer authentication can be ignored
+    #ignore: true
+
+    # peer authentication can be based on cert provided (the peer cert, not its issuer cert)
+    certfp: 41e752df0a4fd753e6c514cb9ff8d5e453a8a39f898311b3dd09b4627269e81a
+
+  # IKE_SA lifetime (in seconds)
+  lifetime: 600
+
+  # dead peer detection (in seconds)
+  dpd: 60
+
+  # IKE_SA crypto algorithms to use
+  encr: [aes256, aes128]
+  integ: [sha512, sha256, sha1]
+  prf: [sha512, sha256, sha1]
+  dh: [2]
+
+  # no protect needed for testing
+  protect:
+
+```
+
+## pyikev2 as EAP-TLS Proxy
+
+```python3 pyikev2.py --verbose --disableXfrm -c config.yaml --listen-port 0 --eapTlsPassThrough```
+
+* disableXfrm disables actually configuring anything with the linux kernel
+* listen-port avoids the need to bind to port 500 which would require root privileges
+* eapTlsPassThrough makes pyikve2 listen on port 8443 and for each inbound connection spans an IKEv2 session and passes through all TLS messages
+
+## sslscan with pyikev2
+
+```sslscan 127.0.0.1:8443```
+
+* connect to pyikve2 and scan the EAP-TLS TLS-Server settings (TLS versions and ciphers supported)

--- a/README.md
+++ b/README.md
@@ -446,3 +446,8 @@ test-tunnel:
 ```sslscan 127.0.0.1:8443```
 
 * connect to pyikve2 and scan the EAP-TLS TLS-Server settings (TLS versions and ciphers supported)
+
+## NAT-T and Float-Port
+
+* --natt enables UDP encapsulation and decapsulation for IKE messages (ESP XFRM config missing)
+* --floatport enables changing UDP port before IKE AUTH phase

--- a/eap.py
+++ b/eap.py
@@ -1,0 +1,7 @@
+class EAPClient:
+    def __init__(self, config):
+        self.config = config
+
+    def handleMessage(self, eap_message):
+        print("handle EAP message")
+        return False

--- a/eap.py
+++ b/eap.py
@@ -1,7 +1,115 @@
+from scapy.layers.eap import EAP, EAP_TLS
+import logging
+from time import sleep
+
 class EAPClient:
-    def __init__(self, config):
+    def __init__(self, config, eapTlsClientSocket = None):
         self.config = config
+        self.running = False
+        self.tlsStarted = False
+        self.eapTlsClientSocket = eapTlsClientSocket
+        self.lastId = None
+        self.lastReply = None
+
+    def stop(self):
+        if self.eapTlsClientSocket is not None:
+            self.eapTlsClientSocket.close()
+            self.eapTlsClientSocket = None
+
+    def log_msg(self, level, message):
+        logging.log(level, f'EAP: {message}')
+
+    def log_error(self, message):
+        self.log_msg(logging.ERROR, message)
+
+    def log_info(self, message):
+        self.log_msg(logging.INFO, message)
+
+    def log_warning(self, message):
+        self.log_msg(logging.WARNING, message)
+
+    def log_debug(self, message):
+        self.log_msg(logging.DEBUG, message)
 
     def handleMessage(self, eap_message):
-        print("handle EAP message")
-        return False
+        eap_message = EAP(eap_message)
+        if eap_message.id == self.lastId:
+            self.log_debug("EAP message repeated")
+            return self.lastReply
+
+        self.lastReply = self._handleMessage(eap_message)
+        self.lastId = eap_message.id
+
+        return self.lastReply
+
+    def _handleMessage(self, eap_message):
+        self.running = True
+        if eap_message.code == EAP.REQUEST:
+            return self.handleRequest(eap_message).build()
+        elif eap_message.code == EAP.SUCCESS:
+            self.running = False
+            self.log_debug("SUCCESS")
+            if self.eapTlsClient is not None:
+                self.eapTlsClient.close()
+            return True
+        elif eap_message.code == EAP.FAILURE:
+            self.running = False
+            self.log_debug("FAILURE")
+            if self.eapTlsClient is not None:
+                self.eapTlsClient.close()
+            return False
+        else:
+            raise Exception(f"Unsupported EAP packet code {eap_message.code}")
+
+    def handleRequest(self, eap_request):
+
+        if eap_request.type == 1:
+            # identity request
+            self.log_debug("handle identity request")
+            return EAP(code=EAP.RESPONSE, id=eap_request.id, type=eap_request.type) / self.config.get("identity")
+        elif eap_request.type == 13 and self.eapTlsClientSocket is not None:
+            if eap_request.S == 1:
+                self.log_debug("Start EAP-TLS")
+                assert(self.tlsStarted == False)
+                self.tlsStarted = True
+            assert(self.tlsStarted == True)
+
+            if len(eap_request.tls_data) > 0:
+                self.log_debug(f"writing {len(eap_request.tls_data)} bytes to eapTlsClient")
+                self.eapTlsClientSocket.sendall(eap_request.tls_data)
+
+            self.log_debug(eap_request)
+            self.log_debug(f"M={eap_request.M}")
+            if eap_request.M == 0:
+                self.log_debug("Reading from eapTlsClient")
+                # no more data from EAP peer
+                # wait for reply from eapTlsClientSocket
+                self.eapTlsClientSocket.settimeout(None) # wait infinity for first data back
+                fromTlsClient = b""
+                while (True):
+                    try:
+                        data = self.eapTlsClientSocket.recv(4096)
+                    except TimeoutError:
+                        data = b""
+                    self.log_debug(f"got {len(data)} bytes")
+                    if len(data) == 0:
+                        self.log_debug("Receiving done")
+                        break
+                    fromTlsClient += data
+                    self.eapTlsClientSocket.settimeout(0.05) # wait only small time to see if more data comes in
+                
+                if len(fromTlsClient) == 0:
+                    self.log_warning("Received no reply from eapTlsClient")
+                self.log_debug(f"EAP_TLS reply having {len(fromTlsClient)} bytes")
+                return EAP_TLS(code=EAP.RESPONSE, id=eap_request.id, type=eap_request.type, L=1, M=0, S=0, tls_message_len=len(fromTlsClient), tls_data=fromTlsClient)
+            else:
+                self.log_debug("Waiting for more EAP TLS messages")
+                # returning EAP_TLS message with empty EAP message
+                return EAP_TLS(code=EAP.RESPONSE, id=eap_request.id, type=eap_request.type, L=0, M=0, S=0, tls_data=b"")
+
+            
+        else:
+            self.log_debug(type(eap_request))
+            self.log_debug(eap_request)
+            
+            raise Exception(f"Unsupported EAP request type {eap_request.type}")

--- a/pyikev2.py
+++ b/pyikev2.py
@@ -30,9 +30,11 @@ parser.add_argument('--no-indent', '-ni', action='store_true',
                     help='Disables JSON indentation to provide a more compact log output.')
 parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
 parser.add_argument('--disableXfrm', action='store_true')
+parser.add_argument('--eapTlsPassThrough', action='store_true')
 args = parser.parse_args()
 
 disableXfrm = args.disableXfrm
+eapTlsPassThrough = args.eapTlsPassThrough
 
 # Get the listening IP addresses
 ip_addresses = []
@@ -75,7 +77,7 @@ except ConfigurationError as ex:
     sys.exit(1)
 
 # create IkeSaController
-ike_sa_controller = IkeSaController(ip_addresses, configuration, disableXfrm, listen_port)
+ike_sa_controller = IkeSaController(ip_addresses, configuration, disableXfrm, listen_port, eapTlsPassThrough)
 
 def signal_handler(*unused):
     print('SIGINT received. Exiting.')

--- a/pyikev2.py
+++ b/pyikev2.py
@@ -23,11 +23,16 @@ parser.add_argument('--verbose', '-v', action='store_true',
                          'the log output!')
 parser.add_argument('--ip-address', '-i', metavar='IPADDR', action='append',
                     help='IP address where the daemon will listen from.')
+parser.add_argument('--listen-port', metavar='PORT', action='store',
+                    help='Port where to listen from.')
 parser.add_argument('--configuration-file', '-c', required=True, metavar='FILE', help='Configuration file.')
 parser.add_argument('--no-indent', '-ni', action='store_true',
                     help='Disables JSON indentation to provide a more compact log output.')
 parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
+parser.add_argument('--disableXfrm', action='store_true')
 args = parser.parse_args()
+
+disableXfrm = args.disableXfrm
 
 # Get the listening IP addresses
 ip_addresses = []
@@ -46,6 +51,8 @@ try:
 except ValueError as ex:
     print(f'There was an error trying to configure the listening sockets: {ex}')
     sys.exit(1)
+
+listen_port = args.listen_port
 
 # set logger
 logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
@@ -68,8 +75,7 @@ except ConfigurationError as ex:
     sys.exit(1)
 
 # create IkeSaController
-ike_sa_controller = IkeSaController(ip_addresses, configuration)
-
+ike_sa_controller = IkeSaController(ip_addresses, configuration, disableXfrm, listen_port)
 
 def signal_handler(*unused):
     print('SIGINT received. Exiting.')

--- a/pyikev2.py
+++ b/pyikev2.py
@@ -31,10 +31,14 @@ parser.add_argument('--no-indent', '-ni', action='store_true',
 parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
 parser.add_argument('--disableXfrm', action='store_true')
 parser.add_argument('--eapTlsPassThrough', action='store_true')
+parser.add_argument('--natt', action='store_true')
+parser.add_argument('--floatport', action='store_true')
 args = parser.parse_args()
 
 disableXfrm = args.disableXfrm
 eapTlsPassThrough = args.eapTlsPassThrough
+natt = args.natt
+floatport = args.floatport
 
 # Get the listening IP addresses
 ip_addresses = []
@@ -77,7 +81,7 @@ except ConfigurationError as ex:
     sys.exit(1)
 
 # create IkeSaController
-ike_sa_controller = IkeSaController(ip_addresses, configuration, disableXfrm, listen_port, eapTlsPassThrough)
+ike_sa_controller = IkeSaController(ip_addresses, configuration, disableXfrm, listen_port, eapTlsPassThrough, natt, floatport)
 
 def signal_handler(*unused):
     print('SIGINT received. Exiting.')


### PR DESCRIPTION
This pull request adds

- support for testing IKEv2 without actually configuring the kernel
- parsing CERT, CERTREQ und EAP payloads
- tunneling EAP-TLS to any TLS-Client, e.g. for sslscan
- more DH transforms
- ability to disable peer ID checking or using certificate fingerprinting instead of providing the public key
- handle SHA-1 PayloadAUTH signatures
- more flexibility in specifying the peer id
